### PR TITLE
docs: add dedicated contributing guide and license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+## Contributing
+
+PRs welcome! See the [Local section in README.md](README.md#local) for build instructions.
+
+### Deploy your own instance
+
+You can deploy your own copy to Vercel in a few clicks:
+
+1. Fork this repo
+2. Go to [vercel.com/new](https://vercel.com/new) and import your fork
+3. No environment variables needed — just deploy
+4. Your server will be at `https://your-project.vercel.app/mcp`
+
+### Release checklist
+
+<details>
+<summary>For maintainers</summary>
+
+```bash
+# 1. Bump version in manifest.json and package.json
+# 2. Build and pack
+pnpm run build && mcpb pack .
+
+# 3. Create GitHub release
+gh release create v0.3.0 excalidraw-mcp-app.mcpb --title "v0.3.0" --notes "What changed"
+
+# 4. Deploy to Vercel
+vercel --prod
+```
+
+</details>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Excalidraw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,13 @@ Restart Claude Desktop.
 ## Usage
 
 Example prompts:
-- "Draw a cute cat using excalidraw"
-- "Draw an architecture diagram showing a user connecting to an API server which talks to a database"
+```text
+Draw a cute cat using excalidraw
+```
+
+```text
+Draw an architecture diagram showing a user connecting to an API server which talks to a database
+```
 
 ## What are MCP Apps and how can I build one?
 
@@ -57,37 +62,7 @@ Text responses can only go so far. Sometimes users need to interact with data, n
 - **Getting started for humans**: [documentation](https://modelcontextprotocol.io/docs/extensions/apps)
 - **Getting started for AIs**: [skill](https://github.com/modelcontextprotocol/ext-apps/blob/main/plugins/mcp-apps/skills/create-mcp-app/SKILL.md)
 
-## Contributing
-
-PRs welcome! See [Local](#local) above for build instructions.
-
-### Deploy your own instance
-
-You can deploy your own copy to Vercel in a few clicks:
-
-1. Fork this repo
-2. Go to [vercel.com/new](https://vercel.com/new) and import your fork
-3. No environment variables needed — just deploy
-4. Your server will be at `https://your-project.vercel.app/mcp`
-
-### Release checklist
-
-<details>
-<summary>For maintainers</summary>
-
-```bash
-# 1. Bump version in manifest.json and package.json
-# 2. Build and pack
-pnpm run build && mcpb pack .
-
-# 3. Create GitHub release
-gh release create v0.3.0 excalidraw-mcp-app.mcpb --title "v0.3.0" --notes "What changed"
-
-# 4. Deploy to Vercel
-vercel --prod
-```
-
-</details>
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution, deployment, and release instructions.
 
 ## Credits
 
@@ -95,4 +70,4 @@ Built with [Excalidraw](https://github.com/excalidraw/excalidraw) — a virtual 
 
 ## License
 
-MIT
+[MIT](https://github.com/excalidraw/excalidraw-mcp/blob/main/LICENSE)


### PR DESCRIPTION
**Description**

Moves contribution and release instructions into a dedicated [CONTRIBUTING.md](CONTRIBUTING.md) file and adds the missing Excalidraw-attributed MIT [LICENSE](LICENSE) file. Updates README links accordingly.

**Testing**

Verified Markdown links and whitespace with `git diff --check`