### PR TITLE
fix: mark create_view as state-changing

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "start": "cross-env NODE_ENV=development npm run build && npm run serve",
     "dev": "cross-env NODE_ENV=development concurrently 'npm run watch' 'npm run serve'",
     "dev:ui": "vite --config vite.config.dev.ts",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test:contract": "npm run build && node --test test/tool-annotations.test.mjs"
   },
   "dependencies": {
     "@excalidraw/excalidraw": "^0.18.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -430,7 +430,7 @@ Call read_me first to learn the element format.`,
           "JSON array string of Excalidraw elements. Must be valid JSON — no comments, no trailing commas. Keep compact. Call read_me first for format reference."
         ),
       }),
-      annotations: { readOnlyHint: true },
+      annotations: { readOnlyHint: false },
       _meta: { ui: { resourceUri } },
     },
     async ({ elements }): Promise<CallToolResult> => {

--- a/test/tool-annotations.test.mjs
+++ b/test/tool-annotations.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { registerTools } from "../dist/server.js";
+
+test("tool annotations reflect state mutation", () => {
+  const tools = new Map();
+  const server = {
+    registerTool(name, config, handler) {
+      tools.set(name, { config, handler });
+      return {};
+    },
+    registerResource() {
+      return {};
+    },
+  };
+  const store = {
+    async save() {},
+    async load() {
+      return null;
+    },
+  };
+  const distDir = fileURLToPath(new URL("../dist", import.meta.url));
+
+  registerTools(server, distDir, store);
+
+  assert.equal(tools.get("read_me").config.annotations.readOnlyHint, true);
+  assert.equal(tools.get("create_view").config.annotations.readOnlyHint, false);
+  assert.deepEqual(
+    tools.get("save_checkpoint").config._meta.ui.visibility,
+    ["app"],
+  );
+});


### PR DESCRIPTION
## Summary

- mark `create_view` as state-changing instead of read-only
- add a focused contract test for `read_me`, `create_view`, and app-only visibility
- add a `test:contract` command that builds the real server bundle before inspecting registration metadata

## Why

`create_view` saves a new checkpoint and produces a user-visible MCP App result. Advertising `readOnlyHint: true` therefore understates its observable state change. The change only corrects tool metadata; it does not alter the input schema, handler, transport, checkpoint format, or model-visible tool inventory.

## Verification

`pnpm run test:contract`

The command runs the existing complete build, registers the bundled tools against a focused test double, and asserts:

- `read_me` remains read-only
- `create_view` is not read-only
- `save_checkpoint` remains app-only

## Post-Deploy Monitoring & Validation

- **Check:** inspect `tools/list` for `create_view.annotations.readOnlyHint`.
- **Healthy signal:** the value is `false`; the five-tool inventory and app-only visibility remain unchanged.
- **Failure signal:** clients still cache the old annotation or any tool disappears from `tools/list`.
- **Mitigation:** redeploy the built revision or revert the metadata line if an unexpected client compatibility issue appears.
- **Window and owner:** verify once after the next upstream deployment; repository maintainers own deployment timing.
